### PR TITLE
Support OneUI 6

### DIFF
--- a/app/src/main/kotlin/ris58h/galaxyfinder/widget/FinderWidget.kt
+++ b/app/src/main/kotlin/ris58h/galaxyfinder/widget/FinderWidget.kt
@@ -4,6 +4,8 @@ import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.widget.RemoteViews
 
 class FinderWidget : AppWidgetProvider() {
@@ -17,7 +19,13 @@ class FinderWidget : AppWidgetProvider() {
 internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
     val views = RemoteViews(context.packageName, R.layout.widget)
 
-    val launchIntent = context.packageManager.getLaunchIntentForPackage("com.samsung.android.app.galaxyfinder")
+    val launchIntent: Intent =
+        if (Build.VERSION.SDK_INT >= 34) {
+            Intent().setClassName("com.sec.android.app.launcher", "com.sec.android.app.launcher.search.SearchActivity")
+        }
+        else {
+            context.packageManager.getLaunchIntentForPackage("com.samsung.android.app.galaxyfinder")!!
+        }
     val pendingIntent = PendingIntent.getActivity(context, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE)
     views.setOnClickPendingIntent(R.id.widget_input, pendingIntent)
 

--- a/app/src/main/kotlin/ris58h/galaxyfinder/widget/FinderWidget.kt
+++ b/app/src/main/kotlin/ris58h/galaxyfinder/widget/FinderWidget.kt
@@ -22,8 +22,7 @@ internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManage
     val launchIntent: Intent? =
         if (Build.VERSION.SDK_INT >= 34) {
             Intent().setClassName("com.sec.android.app.launcher", "com.sec.android.app.launcher.search.SearchActivity")
-        }
-        else {
+        } else {
             context.packageManager.getLaunchIntentForPackage("com.samsung.android.app.galaxyfinder")
         }
     val pendingIntent = PendingIntent.getActivity(context, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE)

--- a/app/src/main/kotlin/ris58h/galaxyfinder/widget/FinderWidget.kt
+++ b/app/src/main/kotlin/ris58h/galaxyfinder/widget/FinderWidget.kt
@@ -19,12 +19,12 @@ class FinderWidget : AppWidgetProvider() {
 internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
     val views = RemoteViews(context.packageName, R.layout.widget)
 
-    val launchIntent: Intent =
+    val launchIntent: Intent? =
         if (Build.VERSION.SDK_INT >= 34) {
             Intent().setClassName("com.sec.android.app.launcher", "com.sec.android.app.launcher.search.SearchActivity")
         }
         else {
-            context.packageManager.getLaunchIntentForPackage("com.samsung.android.app.galaxyfinder")!!
+            context.packageManager.getLaunchIntentForPackage("com.samsung.android.app.galaxyfinder")
         }
     val pendingIntent = PendingIntent.getActivity(context, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE)
     views.setOnClickPendingIntent(R.id.widget_input, pendingIntent)


### PR DESCRIPTION
Use OneUI Home's intent when Android 14 or higher.
Finder doesn't seem to work as it did on OneUI 5 anymore. It's still installed but activities/intents look like they've changed.

Fixes #4 